### PR TITLE
Fix prop types issue with search and filter

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,6 @@
-const { defineConfig } = require("cypress");
+import { defineConfig } from 'cypress';
 
-module.exports = defineConfig({
+export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -1,5 +1,5 @@
 describe('template spec', () => {
   it('passes', () => {
-    cy.visit('https://example.cypress.io')
+    cy.visit('https://')
   })
 })

--- a/src/components/Main/Main.jsx
+++ b/src/components/Main/Main.jsx
@@ -10,7 +10,7 @@ function Main({ responses, setSearchTerm, setFilter }) {
     <>
       <main className="main">
         <Header />
-        <Search handleSearch={setSearchTerm} handleFilter={setFilter} />
+        <Search setSearchTerm={setSearchTerm} setFilter={setFilter} />
         <Responses responses={responses} />
       </main>
     </>

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -3,6 +3,7 @@ import './Search.css'
 import PropTypes from 'prop-types'
 
 function Search({ setSearchTerm, setFilter }) {
+  
   const handleSearch = (e) => {
     setSearchTerm(e.target.value)
   }
@@ -39,8 +40,8 @@ function Search({ setSearchTerm, setFilter }) {
 }
 
 Search.propTypes = {
-  handleSearch: PropTypes.func.isRequired,
-  handleFilter: PropTypes.func.isRequired,
+  setSearchTerm: PropTypes.func.isRequired,
+  setFilter: PropTypes.func.isRequired,
 };
 
 export default Search


### PR DESCRIPTION
## Summary

This PR fixes the prop-types issue with search and filter props. The names of the props were not consistent. 

It also switches from require/module.exports to import/export in cypress.config.js to align with ES module syntax as specified in package.json.